### PR TITLE
Add New Paper (SeeGround, CVPR 2025)

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ ConvNet (SCRC)* [[Paper]](https://www.cv-foundation.org/openaccess/content_cvpr_
 
 4. Rozenberszki, David, et al. **Language-Grounded Indoor 3D Semantic Segmentation in the Wild.** European Conference on Computer Vision. Springer, Tel Aviv, 2022. [[Website]](https://rozdavid.github.io/scannet200) [[Paper]](https://arxiv.org/abs/2204.07761) [[Code]](https://github.com/RozDavid/LanguageGroundedSemseg)
 
+5. Li, Rong, et al. **SeeGround: See and Ground for Zero-Shot Open-Vocabulary 3D Visual Grounding.** IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR), Nashville, TN, 2025. [[Website]](https://seeground.github.io/) [[Paper]](https://arxiv.org/abs/2412.04383) [[Code]](https://github.com/iris0329/SeeGround)
+
 ### Grounding for Embodied Agents (WIP):
 
 1. Shridhar, Mohit, et al. **ALFRED: A Benchmark for Interpreting Grounded Instructions for Everyday Tasks.** arXiv preprint arXiv:1912.01734 (2019). [[Paper]](https://arxiv.org/pdf/1912.01734.pdf) [[Code]](https://github.com/askforalfred/alfred) [[Website]](https://askforalfred.com/) 


### PR DESCRIPTION
Dear authors, thanks for maintaining this useful repository.

We would like to suggest the following work, **SeeGround**, which has been recently accepted to [CVPR 2025](https://cvpr.thecvf.com/Conferences/2025):
- Title: **SeeGround: See and Ground for Zero-Shot Open-Vocabulary 3D Visual Grounding**
- Authors: Rong Li, Shijie Li, Lingdong Kong, Xulei Yang, Junwei Liang
- Venue: CVPR 2025
- Link: https://arxiv.org/abs/2412.04383
- Project Page: https://seeground.github.io
- GitHub: https://github.com/iris0329/SeeGround
- BibTeX:
```bib
@inproceedings{li2025seeground,
  title     = {SeeGround: See and Ground for Zero-Shot Open-Vocabulary 3D Visual Grounding},
  author    = {Li, Rong and Li, Shijie and Kong, Lingdong and Yang, Xulei and Liang, Junwei},
  booktitle = {IEEE/CVF Conference on Computer Vision and Pattern Recognition},
  pages     = {3707-3717},
  year      = {2025}
}
```

Thanks in advance for your help!